### PR TITLE
Fixes to statsd handler

### DIFF
--- a/bucky/statsd.py
+++ b/bucky/statsd.py
@@ -53,6 +53,8 @@ class StatsDHandler(threading.Thread):
     def enqueue_timers(self, stime):
         ret = 0
         for k, v in self.timers.iteritems():
+            if not v: continue
+
             v.sort()
             pct_thresh = 90
             count = len(v)


### PR DESCRIPTION
These are some fixes to problems I ran into using Bucky as a statsd handler.

Primary issue for me was that the stats_counts metrics were missing from the output. Additionally I was able to make the server die rather easily with an IndexError on the timer calculations which is fixed in a commit.

Other minor fixes are in their own commits
