### PR TITLE
Per source prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 bucky.egg-info/
 dist/
+build/

--- a/README.rst
+++ b/README.rst
@@ -150,6 +150,16 @@ config file::
     name_prefix = None
     name_postfix = None
     
+    # prefix_source_name prefixes collectd and metricsd sources
+    # with source name ("collectd.hostname.metric"). This is useful
+    # when you want to have different retention policies for 
+    # data, depending on source.
+    prefix_source_name = False
+    # This sets special per-name source. This overrides above
+    # "prefix_source_name" option.
+    prefix_source_name_collectd = "collectd"
+    prefix_source_name_metricsd = "metricsd"
+    
     # The replacement character is used to munge any '.' characters
     # in name components because it is special to Graphite. Setting
     # this to None will prevent this step.

--- a/README.rst
+++ b/README.rst
@@ -155,10 +155,12 @@ config file::
     # when you want to have different retention policies for 
     # data, depending on source.
     prefix_source_name = False
-    # This sets special per-name source. This overrides above
-    # "prefix_source_name" option.
-    prefix_source_name_collectd = "collectd"
-    prefix_source_name_metricsd = "metricsd"
+    
+    # This sets special per-name source. These override
+    # "prefix_source_name" option - if these are set, appropriate
+    # source events are always prefixed.
+    #prefix_source_name_collectd = "collectd"
+    #prefix_source_name_metricsd = "metricsd"
     
     # The replacement character is used to munge any '.' characters
     # in name components because it is special to Graphite. Setting

--- a/bucky/cfg.py
+++ b/bucky/cfg.py
@@ -27,6 +27,9 @@ graphite_reconnect_delay = 5
 
 full_trace = False
 
+prefix_source_name = False
+prefix_source_name_collectd = "collectd"
+
 name_prefix = None
 name_postfix = None
 name_replace_char = '_'

--- a/bucky/collectd.py
+++ b/bucky/collectd.py
@@ -240,7 +240,7 @@ class CollectDConverter(object):
             log.exception("Exception in sample handler  %s (%s):" % (
                 sample["plugin"], handler))
             return
-        stat = statname(sample.get("host", ""), name)
+        stat = statname(sample.get("host", ""), name, "collectd")
         return stat, sample["value_type"], sample["value"], int(sample["time"])
 
     def _load_converters(self, cfg):

--- a/bucky/metricsd.py
+++ b/bucky/metricsd.py
@@ -93,7 +93,7 @@ class MetricsDParser(object):
             value, data = self.parse_number(data)
         else:
             value = None
-        stat = statname(hostname, name.split("."))
+        stat = statname(hostname, name.split("."), "metricsd")
         cmd = MetricsDCommand(stat, mtype, action, value)
         return cmd, data
 

--- a/bucky/names.py
+++ b/bucky/names.py
@@ -56,10 +56,15 @@ def strip_duplicates(parts):
     return ret
 
 
-def statname(host, nameparts):
+def statname(host, nameparts, source=None):
     parts = []
     if cfg.name_prefix:
         parts.append(cfg.name_prefix)
+    if source:
+        if getattr(cfg, "prefix_source_name_%s", False):
+            parts.append(getattr(cfg, "prefix_source_name_%s" % source, False))
+        elif cfg.prefix_source_name:
+            parts.append(source)
     parts.extend(hostname(host))
     parts.extend(nameparts)
     if cfg.name_postfix:


### PR DESCRIPTION
This patch adds three configuration options for setting per source prefixes easily. It's not unusual to have different retention policy for collectd sources and for example statsd.

It's difficult to configure graphite to have retention policy for every collectd host - whole point of graphite is to be configuration free. In our setup with over 100 hosts collectd statistics are saved for 90 days with lower resolution, default is three years with one minute resolution, and for example "fast.app1.failures" is saved only for few days with high resolution.

    # prefix_source_name prefixes collectd and metricsd sources
    # with source name ("collectd.hostname.metric"). This is useful
    # when you want to have different retention policies for 
    # data, depending on source.
    prefix_source_name = False
    
    # This sets special per-name source. These override
    # "prefix_source_name" option - if these are set, appropriate
    # source events are always prefixed.
    #prefix_source_name_collectd = "collectd"
    #prefix_source_name_metricsd = "metricsd"


Also, .gitignore line for build/ directory.