### PR TITLE
Defer joining hostname and statname and allow custom clients.

### DIFF
--- a/bucky/carbon.py
+++ b/bucky/carbon.py
@@ -19,6 +19,8 @@ import socket
 import sys
 import time
 
+from bucky.names import statname
+
 
 log = logging.getLogger(__name__)
 
@@ -68,7 +70,8 @@ class CarbonClient(object):
         except:
             pass
 
-    def send(self, stat, value, mtime):
+    def send(self, host, name, value, mtime):
+        stat = statname(host, name)
         mesg = "%s %s %s\n" % (stat, value, mtime)
         for i in xrange(self.max_reconnects):
             try:

--- a/bucky/cfg.py
+++ b/bucky/cfg.py
@@ -32,3 +32,5 @@ name_postfix = None
 name_replace_char = '_'
 name_strip_duplicates = True
 name_host_trim = []
+
+custom_clients = []

--- a/bucky/main.py
+++ b/bucky/main.py
@@ -149,12 +149,13 @@ def main():
         servers.append(stype(sampleq, cfg))
         servers[-1].start()
 
-    cli = carbon.CarbonClient(cfg)
+    clients = [cli(cfg) for cli in cfg.custom_clients + [carbon.CarbonClient]]
 
     while True:
         try:
-            stat, value, time = sampleq.get(True, 1)
-            cli.send(stat, value, time)
+            host, name, value, time = sampleq.get(True, 1)
+            for cli in clients:
+                cli.send(host, name, value, time)
         except Queue.Empty:
             pass
         for srv in servers:

--- a/bucky/names.py
+++ b/bucky/names.py
@@ -56,11 +56,13 @@ def strip_duplicates(parts):
     return ret
 
 
-def statname(host, nameparts):
+def statname(host, name):
+    nameparts = name.split('.')
     parts = []
     if cfg.name_prefix:
         parts.append(cfg.name_prefix)
-    parts.extend(hostname(host))
+    if host:
+        parts.extend(hostname(host))
     parts.extend(nameparts)
     if cfg.name_postfix:
         parts.append(cfg.name_postfix)
@@ -69,4 +71,3 @@ def statname(host, nameparts):
     if cfg.name_strip_duplicates:
         parts = strip_duplicates(parts)
     return ".".join(parts)
-

--- a/tests/001-test-statsd.py
+++ b/tests/001-test-statsd.py
@@ -21,9 +21,9 @@ import bucky.statsd
 @t.udp_srv(bucky.statsd.StatsDServer)
 def test_simple_counter(q, s):
     s.send("gorm:1|c")
-    t.same_stat("stats.gorm", 2, q.get())
-    t.same_stat("stats_counts.gorm", 1, q.get())
-    t.same_stat("stats.numStats", 1, q.get())
+    t.same_stat(None, "stats.gorm", 2, q.get())
+    t.same_stat(None, "stats_counts.gorm", 1, q.get())
+    t.same_stat(None, "stats.numStats", 1, q.get())
 
 
 @t.set_cfg("statsd_flush_time", 0.5)
@@ -31,18 +31,18 @@ def test_simple_counter(q, s):
 def test_multiple_messages(q, s):
     s.send("gorm:1|c")
     s.send("gorm:1|c")
-    t.same_stat("stats.gorm", 4, q.get())
-    t.same_stat("stats_counts.gorm", 2, q.get())
-    t.same_stat("stats.numStats", 1, q.get())
+    t.same_stat(None, "stats.gorm", 4, q.get())
+    t.same_stat(None, "stats_counts.gorm", 2, q.get())
+    t.same_stat(None, "stats.numStats", 1, q.get())
 
 
 @t.set_cfg("statsd_flush_time", 0.5)
 @t.udp_srv(bucky.statsd.StatsDServer)
 def test_larger_count(q, s):
     s.send("gorm:5|c")
-    t.same_stat("stats.gorm", 10, q.get())
-    t.same_stat("stats_counts.gorm", 5, q.get())
-    t.same_stat("stats.numStats", 1, q.get())
+    t.same_stat(None, "stats.gorm", 10, q.get())
+    t.same_stat(None, "stats_counts.gorm", 5, q.get())
+    t.same_stat(None, "stats.numStats", 1, q.get())
 
 
 @t.set_cfg("statsd_flush_time", 0.5)
@@ -58,11 +58,11 @@ def test_multiple_counters(q, s):
     }
     for i in range(4):
         stat = q.get()
-        t.isin(stat[0], stats)
-        t.eq(stats[stat[0]], stat[1])
-        t.gt(stat[1], 0)
-        stats.pop(stat[0])
-    t.same_stat("stats.numStats", 2, q.get())
+        t.isin(stat[1], stats)
+        t.eq(stats[stat[1]], stat[2])
+        t.gt(stat[2], 0)
+        stats.pop(stat[1])
+    t.same_stat(None, "stats.numStats", 2, q.get())
 
 
 @t.set_cfg("statsd_flush_time", 0.5)
@@ -71,10 +71,10 @@ def test_simple_timer(q, s):
     for i in range(9):
         s.send("gorm:1|ms")
     s.send("gorm:2|ms")
-    t.same_stat("stats.timers.gorm.mean", 1, q.get())
-    t.same_stat("stats.timers.gorm.upper", 2, q.get())
-    t.same_stat("stats.timers.gorm.upper_90", 1, q.get())
-    t.same_stat("stats.timers.gorm.lower", 1, q.get())
-    t.same_stat("stats.timers.gorm.count", 10, q.get())
-    t.same_stat("stats.numStats", 1, q.get())
+    t.same_stat(None, "stats.timers.gorm.mean", 1, q.get())
+    t.same_stat(None, "stats.timers.gorm.upper", 2, q.get())
+    t.same_stat(None, "stats.timers.gorm.upper_90", 1, q.get())
+    t.same_stat(None, "stats.timers.gorm.lower", 1, q.get())
+    t.same_stat(None, "stats.timers.gorm.count", 10, q.get())
+    t.same_stat(None, "stats.numStats", 1, q.get())
 

--- a/tests/t.py
+++ b/tests/t.py
@@ -75,10 +75,10 @@ class udp_srv(object):
         return False
 
 
-def same_stat(name, value, stat):
-    eq(name, stat[0])
-    eq(value, stat[1])
-    gt(stat[2], 0)
+def same_stat(host, name, value, stat):
+    eq(name, stat[1])
+    eq(value, stat[2])
+    gt(stat[3], 0)
 
 
 def eq(a, b):


### PR DESCRIPTION
Not all potential clients need hostnames and metric names joined together, so
we defer calling names.statname() until just before shipping data to Carbon.
Messages in the queue are now 4-tuples.

Also added a simple hook for custom clients. A client must respond to init/1
and send/4. They're not run in separate threads, so some care should be taken
to not hog interpreter time.

Updated tests to pass with the new message format.
