### PR TITLE
Setting handler log level by name

### DIFF
--- a/bucky/main.py
+++ b/bucky/main.py
@@ -138,7 +138,7 @@ def main():
     # processing pass to override values in cfg
     parser.parse_args(values=cfg)
 
-    lvl = levels.get(cfg.log_level, handler.level)
+    lvl = levels.get(cfg.log_level, cfg.log_level)
     handler.setLevel(lvl)
 
     sampleq = Queue.Queue()


### PR DESCRIPTION
The logging module uses an integer for handler.setLevel(), so we need a mapping from level name to integer.
