### PR TITLE
Statsd supports floats for gauge values but bucky does not accept them.

### DIFF
--- a/bucky/statsd.py
+++ b/bucky/statsd.py
@@ -155,7 +155,7 @@ class StatsDHandler(threading.Thread):
 
     def handle_gauge(self, key, fields):
         try:
-            val = int(fields[0] or 0)
+            val = float(fields[0] or 0)
         except:
             self.bad_line()
             return


### PR DESCRIPTION
This fix changes the way values are read from gauges. Rather than parse and int from the string we instead parse a float from the string. Graphite handles floats fine and so a float should be good enough for all cases.
