### PR TITLE
Allow prefix and postfix to have multiple parts.

### DIFF
--- a/bucky/cfg.py
+++ b/bucky/cfg.py
@@ -30,7 +30,9 @@ graphite_pickle_buffer_size = 500
 full_trace = False
 
 name_prefix = None
+name_prefix_parts = None
 name_postfix = None
+name_postfix_parts = None
 name_replace_char = '_'
 name_strip_duplicates = True
 name_host_trim = []

--- a/bucky/names.py
+++ b/bucky/names.py
@@ -61,9 +61,13 @@ def statname(host, name):
     parts = []
     if cfg.name_prefix:
         parts.append(cfg.name_prefix)
+    if cfg.name_prefix_parts:
+        parts.extend(cfg.name_prefix_parts)
     if host:
         parts.extend(hostname(host))
     parts.extend(nameparts)
+    if cfg.name_postfix_parts:
+        parts.append(cfg.name_postfix_parts)
     if cfg.name_postfix:
         parts.append(cfg.name_postfix)
     if cfg.name_replace_char is not None:


### PR DESCRIPTION
Currently, a dotted prefix or postfix is converted with _ replacement.  This patch adds two new config options to allow a multi-level prefix and postfix.
