### PR TITLE
Gauges are constant until overwritten, and not reset at flush time.

### DIFF
--- a/bucky/statsd.py
+++ b/bucky/statsd.py
@@ -91,7 +91,6 @@ class StatsDHandler(threading.Thread):
         for k, v in self.gauges.iteritems():
             stat = "stats.gauges.%s" % k
             self.enqueue(stat, v, stime)
-            self.gauges[k] = 0
             ret += 1
         return ret
 


### PR DESCRIPTION
The statsd documentation says (http://statsd.readthedocs.org/en/v1.0.0/types.html):

"Gauges are a constant data type. They are not subject to averaging, and they don't change unless you change them. That is, once you set a gauge value, it will be a flat line on the graph until you change it again."

Bucky resets the gauge at flush time.  My patch restores etsy statsd behavior.
