### PR TITLE
(optionally) change process name of children

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,22 @@ local Graphite (Carbon) daemon on 127.0.0.1:2003.
 These are all optional as illustrated below. You can also disable the
 CollectD or StatsD servers completely if you so desire.
 
+Process Names
+-------------
+
+If the py-setproctitle_ module is installed Bucky will use it to set
+user readable process names. This will make the child processes of Bucky
+easier to identify. Please note that this is completely optional.
+
+To install py-setproctitle_ run::
+
+    $ easy_install setproctitle
+    # or
+    $ pip install setproctitle
+
+.. _py-setproctitle: https://github.com/dvarrazzo/py-setproctitle
+
+
 Running Bucky For Real
 ----------------------
 
@@ -197,7 +213,7 @@ good to go.
 
 
 Configuring MetricsD
-------------------
+--------------------
 
 TODO
 

--- a/bucky/client.py
+++ b/bucky/client.py
@@ -16,6 +16,13 @@
 
 import multiprocessing
 
+try:
+    from setproctitle import setproctitle
+except ImportError:
+    def setproctitle(title):
+        pass
+
+
 class Client(multiprocessing.Process):
     def __init__(self, pipe):
         super(Client, self).__init__()
@@ -23,6 +30,7 @@ class Client(multiprocessing.Process):
         self.pipe = pipe
 
     def run(self):
+        setproctitle("bucky: %s" % self.__class__.__name__)
         while True:
             self.send(*self.pipe.recv())
 

--- a/bucky/udpserver.py
+++ b/bucky/udpserver.py
@@ -19,6 +19,12 @@ import multiprocessing
 
 import bucky.cfg as cfg
 
+try:
+    from setproctitle import setproctitle
+except ImportError:
+    def setproctitle(title):
+        pass
+
 
 log = logging.getLogger(__name__)
 
@@ -39,6 +45,7 @@ class UDPServer(multiprocessing.Process):
             sys.exit(1)
 
     def run(self):
+        setproctitle("bucky: %s" % self.__class__.__name__)
         while True:
             data, addr = self.sock.recvfrom(65535)
             log.debug("Received UDP packet from %s:%s" % addr)


### PR DESCRIPTION
settings the process title to a human readable name helps
to identify which subprocess is doing what. besides looking nice
it also helps to give a better inside in what parts of bucky are
using resources when looking at the output of ps, top and alikes.
