### PR TITLE
Updated THANKS

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -4,5 +4,5 @@ Bucky Thanks
 A number of people have contributed to Bucky by reporting problems,
 suggesting improvements or submitting changes. Some of these people are:
 
-    Your Name Here <your.name@here.com>
+    Mike Kazantsev <mk.fraggod@gmail.com>
 


### PR DESCRIPTION
After reading comment in #24, ran `git log | grep -c mk.fragg` and found that it only goes up to 29.
While it's a nice prime number, 30 is more "round" in decimal and even nicer!
Clearly this is a major bug that should be fixed immediately, hence this important PR.
