### PR TITLE
Fix name_postfix_parts config option.

### DIFF
--- a/bucky/names.py
+++ b/bucky/names.py
@@ -67,7 +67,7 @@ def statname(host, name):
         parts.extend(hostname(host))
     parts.extend(nameparts)
     if cfg.name_postfix_parts:
-        parts.append(cfg.name_postfix_parts)
+        parts.extend(cfg.name_postfix_parts)
     if cfg.name_postfix:
         parts.append(cfg.name_postfix)
     if cfg.name_replace_char is not None:


### PR DESCRIPTION
Simple fix for an option that nobody ever used (I implemented it in symmetry to name_prefix_parts, which I do use, and noticed this error in my code review).