### PR TITLE
Add statsd timer metrics enable/disable option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -216,6 +216,19 @@ config file::
     # - stats.timers.my.awesome.timer.mean_90
     statsd_percentile_thresholds = [90]
 
+    # Timer metrics
+    # These will enable or disable computing and futher dispatching metrics for specified type.
+    # Corresponding percentile metric will be disabled as well.
+    statsd_timer_mean = True
+    statsd_timer_upper = True
+    statsd_timer_lower = True
+    statsd_timer_count = True
+    statsd_timer_count_ps = True
+    statsd_timer_sum = True
+    statsd_timer_sum_squares = True
+    statsd_timer_median = True
+    statsd_timer_std = True
+
     # Basic Graphite configuration
     graphite_ip = "127.0.0.1"
     graphite_port = 2003

--- a/bucky/cfg.py
+++ b/bucky/cfg.py
@@ -55,6 +55,16 @@ statsd_onlychanged_gauges = True
 
 statsd_percentile_thresholds = [90]  # percentile thresholds for statsd timers
 
+statsd_timer_mean = True
+statsd_timer_upper = True
+statsd_timer_lower = True
+statsd_timer_count = True
+statsd_timer_count_ps = True
+statsd_timer_sum = True
+statsd_timer_sum_squares = True
+statsd_timer_median = True
+statsd_timer_std = True
+
 graphite_ip = "127.0.0.1"
 graphite_port = 2003
 graphite_max_reconnects = 60


### PR DESCRIPTION
Not Pythonist, don't bash me hard :poop: I went most straightforward way i know.

Can't run unit tests on local machine because ``Address already in use`` issue, but i think Travis will do file 🚥 

## Perfomance tests

Test: https://gist.github.com/t3hk0d3/594a41b2344244e5335cb33ba9b66040
Run:  `` $ python statsd_perfomance.py ``

### Results 

Hardware: Mac Book Pro 15" Late 2013, Intel Core i7 2 GHz

|  Mode  | Series 1   |  Series 2 | Series 3 |  Series 4 | Average |
| :---           | ---: |  ---: |  ---: |  ---: | ---: | 
| **Before**  | 27.19 | 26.63 | 27.25 | 25.73 | 26.70  |
| **After** | 25.76 | 25.92 | 26.44 | 26.07 | 26.05 | 

Closes #57 