### PR TITLE
Add a max queue size to prevent excessive memory usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ bucky.egg-info/
 build/
 dist/
 .idea/
+.env/

--- a/README.rst
+++ b/README.rst
@@ -136,6 +136,11 @@ config file::
     # Valid log levels: DEBUG, INFO, WARNING, ERROR, CRITICAL
     log_level = "INFO"
 
+    # The size of the input queue 0 is no max size.
+    # this is useful to set if you are concern about bucky consuming to
+    # much memory if the downstream systems are offline
+    max_sample_queue = 0
+
     # Whether to print the entire stack trace for errors encountered
     # when loading the config file
     full_trace = False

--- a/bucky/cfg.py
+++ b/bucky/cfg.py
@@ -6,6 +6,7 @@ uid = None
 gid = None
 directory = "/var/lib/bucky"
 process_join_timeout = 2
+max_sample_queue = 0
 
 sentry_enabled = False
 sentry_dsn = None

--- a/bucky/main.py
+++ b/bucky/main.py
@@ -253,7 +253,7 @@ def main():
 
 class Bucky(object):
     def __init__(self, cfg):
-        self.sampleq = multiprocessing.Queue()
+        self.sampleq = multiprocessing.Queue(cfg.max_sample_queue)
 
         stypes = []
         if cfg.metricsd_enabled:


### PR DESCRIPTION

this is useful to set if you are concern about bucky consuming to much memory if the downstream systems are offline